### PR TITLE
Make token generation more secure

### DIFF
--- a/lib/qbwc/session.rb
+++ b/lib/qbwc/session.rb
@@ -18,7 +18,7 @@ class QBWC::Session
     @iterator_id = nil
     @initial_job_count = pending_jobs.length
 
-    @ticket = ticket || Digest::SHA1.hexdigest("#{Rails.application.config.secret_token}#{Time.now.to_i}")
+    @ticket = ticket || Digest::SHA1.hexdigest("#{Rails.application.config.secret_token}#{SecureRandom.uuid}#{Time.now.to_f}")
 
     @@session = self
     reset(ticket.nil?)

--- a/test/qbwc/integration/session_test.rb
+++ b/test/qbwc/integration/session_test.rb
@@ -126,5 +126,16 @@ class SessionTest < ActionDispatch::IntegrationTest
     assert_equal 100, susan_session.progress
   end
 
+  test "session ticket generated does not collide with others generated in the same second" do
+    QBWC.add_job(:session_test_1, true, COMPANY, ConditionalTestWorker)
 
+    100.times do
+      timothy_session  = QBWC::Session.new("timothy", COMPANY)
+      margaret_session = QBWC::Session.new("margaret", COMPANY)
+      puts timothy_session.ticket
+      puts "_______________"
+      puts margaret_session.ticket
+      assert timothy_session.ticket != margaret_session.ticket
+    end
+  end
 end

--- a/test/qbwc/integration/session_test.rb
+++ b/test/qbwc/integration/session_test.rb
@@ -129,12 +129,10 @@ class SessionTest < ActionDispatch::IntegrationTest
   test "session ticket generated does not collide with others generated in the same second" do
     QBWC.add_job(:session_test_1, true, COMPANY, ConditionalTestWorker)
 
-    100.times do
+    Time.stub :now, Time.at(1466694710) do
       timothy_session  = QBWC::Session.new("timothy", COMPANY)
       margaret_session = QBWC::Session.new("margaret", COMPANY)
-      puts timothy_session.ticket
-      puts "_______________"
-      puts margaret_session.ticket
+
       assert timothy_session.ticket != margaret_session.ticket
     end
   end


### PR DESCRIPTION
Uses a float for the time for high precision, and adds a random value to seed the hash. This prevents two users who authenticate in the same second from getting the same ticket.
