### PR TITLE
Bump `wash_out` to `0.12.0`

### DIFF
--- a/lib/qbwc/controller.rb
+++ b/lib/qbwc/controller.rb
@@ -10,9 +10,9 @@ module QBWC
     def self.included(base)
       base.class_eval do
         soap_service
-        skip_before_filter :_authenticate_wsse, :_map_soap_parameters, :only => :qwc
-        before_filter :get_session, :except => [:qwc, :authenticate, :_generate_wsdl]
-        after_filter :save_session, :except => [:qwc, :authenticate, :_generate_wsdl, :close_connection, :connection_error]
+        skip_before_action :_authenticate_wsse, :_map_soap_parameters, :only => :qwc
+        before_action :get_session, :except => [:qwc, :authenticate, :_generate_wsdl]
+        after_action :save_session, :except => [:qwc, :authenticate, :_generate_wsdl, :close_connection, :connection_error]
 
         # wash_out changed the format of app/views/wash_with_soap/rpc/response.builder in commit
         # https://github.com/inossidabile/wash_out/commit/24a77f4a3d874562732c6e8c3a30e8defafea7cb

--- a/qbwc.gemspec
+++ b/qbwc.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0.0'
 
   s.add_dependency "qbxml", [">= 0.3.0"]
-  s.add_dependency "wash_out", ["= 0.10.0"]
+  s.add_dependency "wash_out", ["= 0.12.0"]
 
   s.add_development_dependency('rb-fsevent')
   s.add_development_dependency('webmock')


### PR DESCRIPTION
For Rails 5.1 since it's source uses `around_filter` which has been removed